### PR TITLE
J24CR-19 Back-End: API to DELETE a Warehouse

### DIFF
--- a/controllers/warehouses-controller.js
+++ b/controllers/warehouses-controller.js
@@ -2,10 +2,10 @@ const knex = require("knex")(require("../knexfile"));
 
 const index = async (_req, res) => {
   try {
-    const data = await knex('warehouses');
+    const data = await knex("warehouses");
     res.status(200).json(data);
-  } catch(err) {
-    res.status(400).send(`Error retrieving warehouses: ${err}`)
+  } catch (err) {
+    res.status(400).send(`Error retrieving warehouses: ${err}`);
   }
 };
 
@@ -34,17 +34,18 @@ const findOne = async (req, res) => {
   }
 };
 
-
 const inventories = async (req, res) => {
   try {
-      // Check if the warehouse ID exists
-      const warehouse = await knex("warehouses")
+    // Check if the warehouse ID exists
+    const warehouse = await knex("warehouses")
       .where({ id: req.params.id })
       .first();
 
     if (!warehouse) {
       // If warehouse doesn't exist, return 404 response
-      return res.status(404).json({ message: `Warehouse with ID: ${req.params.id} not found` });
+      return res
+        .status(404)
+        .json({ message: `Warehouse with ID: ${req.params.id} not found` });
     }
 
     // Warehouse exists, proceed to fetch inventories
@@ -60,12 +61,30 @@ const inventories = async (req, res) => {
   }
 };
 
+const remove = async (req, res) => {
+  try {
+    const rowsDeleted = await knex("warehouses")
+      .where({ id: req.params.id })
+      .delete();
 
+    if (rowsDeleted === 0) {
+      return res
+        .status(404)
+        .json({ message: `warehouses with ID ${req.params.id} not found` });
+    }
 
-
+    // No Content response
+    res.sendStatus(204);
+  } catch (error) {
+    res.status(500).json({
+      message: `Unable to delete user: ${error}`,
+    });
+  }
+};
 
 module.exports = {
   index,
   findOne,
   inventories,
-}
+  remove,
+};

--- a/routes/warehouses-routes.js
+++ b/routes/warehouses-routes.js
@@ -2,7 +2,7 @@ const router = require('express').Router();
 const warehousesController = require('../controllers/warehouses-controller');
 
 router.route("/").get(warehousesController.index);
-router.route('/:id').get(warehousesController.findOne);
+router.route('/:id').get(warehousesController.findOne).delete(warehousesController.remove);;
 router.route('/:id/inventories').get(warehousesController.inventories);
 
 module.exports = router;


### PR DESCRIPTION
Added DELETE endpoint to Express router in warehouses controller to allow deletion of a specific warehouse by ID.
If the warehouse ID is not found, it will return a 404 .
If it is successfully deleted, it will return 204 with no response body.